### PR TITLE
feat: handoff templates, feedback loops, and anti-pattern guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+- **Handoff Templates**: Structured output formatting between nodes via edge configuration. Built-in presets: `standard`, `qa-review`, `qa-feedback`, `escalation`. Custom templates supported inline or by name.
+- **Feedback Edges**: Engine-managed Dev-QA retry loops with automatic feedback injection. Configurable `maxRetries` and escalation policies (`skip`, `fail`, `reroute`). New events: `feedback_retry`, `feedback_escalation`.
+- **Anti-Pattern Guards**: Post-completion output quality checks with configurable `warn`/`block` modes.
+  - Evidence guard: Pattern-based detection of unsupported claims (e.g., "all tests pass" without test output)
+  - Scope creep guard: LLM-based detection of unrequested work beyond the task scope
+  - Guards configurable per-node or engine-wide. New events: `guard_warning`, `guard_blocked`.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Multi-agent DAG orchestration engine for TypeScript. Define agents as nodes, wir
 - **Cost tracking** — per-agent and per-swarm token usage with budget enforcement
 - **Streaming events** — real-time `AsyncGenerator` events for UI and logging
 - **Pluggable adapters** — persistence, memory, context, codebase, persona, lifecycle hooks
+- **Handoff templates** — structured output formatting between nodes with built-in presets
+- **Feedback edges** — engine-managed retry loops with escalation policies
+- **Anti-pattern guards** — post-completion output quality checks (evidence, scope creep)
 - **TypeScript-first** — strict mode, full type definitions, ESM
 
 ## Install
@@ -172,6 +175,108 @@ Every `engine.run()` yields typed events:
 | `loop_iteration` | Loop cycle started |
 | `budget_warning` | Approaching token budget limit |
 | `budget_exceeded` | Token budget exceeded |
+| `feedback_retry` | Feedback loop: re-running producer with reviewer feedback |
+| `feedback_escalation` | Feedback loop: max retries exhausted, escalation triggered |
+| `guard_warning` | Guard triggered in warn mode |
+| `guard_blocked` | Guard triggered in block mode |
+
+## Handoff Templates
+
+Shape the output format between connected nodes using built-in presets or custom templates. The template injects formatting instructions into the producing agent's system prompt.
+
+```ts
+// Use a built-in preset: 'standard', 'qa-review', 'qa-feedback', 'escalation'
+engine.dag()
+  .agent('developer', devAgent)
+  .agent('reviewer', reviewAgent)
+  .edge('developer', 'reviewer', { handoff: 'qa-review' })
+  .build();
+
+// Or define a custom template inline
+engine.dag()
+  .agent('researcher', researchAgent)
+  .agent('writer', writerAgent)
+  .edge('researcher', 'writer', {
+    handoff: {
+      id: 'research-handoff',
+      sections: [
+        { key: 'findings', label: 'Key Findings', required: true },
+        { key: 'sources', label: 'Sources', required: true },
+        { key: 'gaps', label: 'Knowledge Gaps' },
+      ],
+    },
+  })
+  .build();
+```
+
+## Feedback Edges
+
+Set up engine-managed retry loops where a reviewer node can send work back to a producer. The engine tracks iteration count, injects previous feedback into the producer's context, and escalates when retries are exhausted.
+
+```ts
+const dag = engine.dag()
+  .agent('developer', devAgent)
+  .agent('qa', qaAgent)
+  .agent('senior', seniorAgent)
+  .edge('developer', 'qa', { handoff: 'qa-review' })
+  .feedbackEdge({
+    from: 'qa',
+    to: 'developer',
+    maxRetries: 3,
+    evaluate: {
+      type: 'rule',
+      fn: (output) => output.toLowerCase().includes('approve') ? 'pass' : 'fail',
+    },
+    passLabel: 'pass',
+    escalation: { action: 'reroute', reroute: 'senior' },
+  })
+  .build();
+```
+
+Events emitted during feedback loops:
+
+| Event | Description |
+|---|---|
+| `feedback_retry` | QA rejected; re-running producer with feedback injected |
+| `feedback_escalation` | Max retries exhausted; escalation policy triggered |
+
+## Anti-Pattern Guards
+
+Guards run after a node completes and check output quality. Each guard operates in `warn` mode (emit event, continue) or `block` mode (emit event, halt the node).
+
+### Per-Node Guards
+
+```ts
+engine.dag()
+  .agent('developer', {
+    ...devAgent,
+    guards: [
+      { id: 'no-empty-claims', type: 'evidence', mode: 'block' },
+      { id: 'stay-on-task', type: 'scope-creep', mode: 'warn' },
+    ],
+  })
+  .build();
+```
+
+### Engine-Wide Guards
+
+Apply guards to every node in the DAG:
+
+```ts
+const engine = new SwarmEngine({
+  providers: { /* ... */ },
+  guards: [
+    { id: 'global-evidence', type: 'evidence', mode: 'warn' },
+  ],
+});
+```
+
+Guard events:
+
+| Event | Description |
+|---|---|
+| `guard_warning` | Guard triggered in `warn` mode — output passed through |
+| `guard_blocked` | Guard triggered in `block` mode — node output rejected |
 
 ## Configuration
 

--- a/src/agent/agentic-runner.ts
+++ b/src/agent/agentic-runner.ts
@@ -17,6 +17,8 @@ export interface AgenticRunnerParams {
   memory: SwarmMemory;
   upstreamOutputs?: { nodeId: string; agentRole: string; output: string }[];
   signal?: AbortSignal;
+  handoffTemplate?: import('../types.js').HandoffTemplate;
+  feedbackContext?: import('../types.js').FeedbackContext;
 }
 
 /**

--- a/src/agent/agentic-runner.ts
+++ b/src/agent/agentic-runner.ts
@@ -45,6 +45,9 @@ export class AgenticRunner {
 
   async *run(params: AgenticRunnerParams): AsyncGenerator<SwarmEvent> {
     const { nodeId, agent, task, adapter, memory, upstreamOutputs, signal } = params;
+    // TODO: handoffTemplate and feedbackContext are accepted but not yet injected
+    // into agentic backends. Agentic adapters manage their own context assembly,
+    // so these need a new adapter.run() parameter or convention. (#follow-up)
 
     // 1. Yield agent_start
     yield {

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -19,6 +19,8 @@ export interface AgentRunParams {
   memory: SwarmMemory;
   upstreamOutputs?: { nodeId: string; agentRole: string; output: string }[];
   signal?: AbortSignal;
+  handoffTemplate?: import('../types.js').HandoffTemplate;
+  feedbackContext?: import('../types.js').FeedbackContext;
 }
 
 /**
@@ -48,7 +50,7 @@ export class AgentRunner {
   }
 
   async *run(params: AgentRunParams): AsyncGenerator<SwarmEvent> {
-    const { nodeId, agent, task, memory, upstreamOutputs, signal } = params;
+    const { nodeId, agent, task, memory, upstreamOutputs, signal, handoffTemplate, feedbackContext } = params;
     const startTime = Date.now();
 
     // Resolve provider: use agent's providerId if available, else default
@@ -77,6 +79,8 @@ export class AgentRunner {
         upstreamOutputs,
         swarmMemory: memory,
         agentId: agent.id,
+        handoffTemplate,
+        feedbackContext,
       });
 
       // 3. Get agent communication tools

--- a/src/context/assembler.ts
+++ b/src/context/assembler.ts
@@ -4,10 +4,13 @@ import type {
   MemoryProvider,
   CodebaseProvider,
   PersonaProvider,
+  HandoffTemplate,
+  FeedbackContext,
 } from '../types.js';
 import type { SwarmMemory } from '../memory/index.js';
 import { TokenBudget } from './budget.js';
 import { Logger } from '../logger.js';
+import { formatHandoffInstructions } from '../handoffs/formatter.js';
 
 interface UpstreamOutput {
   nodeId: string;
@@ -25,6 +28,8 @@ export interface AssembleParams {
   threadHistory?: Message[];
   entityType?: string;
   entityId?: string;
+  handoffTemplate?: HandoffTemplate;
+  feedbackContext?: FeedbackContext;
 }
 
 interface AssemblerDeps {
@@ -99,6 +104,31 @@ export class ContextAssembler {
     // --- Priority 1: Task ---
     budget.add('task', `## Task\n${task}`, 1);
     this.logger.debug('Context section added', { section: 'task', charLength: task.length });
+
+    // --- Priority 1: Handoff output instructions ---
+    if (params.handoffTemplate) {
+      const instructions = formatHandoffInstructions(params.handoffTemplate);
+      budget.add('handoff', instructions, 1);
+      this.logger.debug('Context section added', { section: 'handoff', charLength: instructions.length });
+    }
+
+    // --- Priority 1: Feedback context (retry loop) ---
+    if (params.feedbackContext) {
+      const { iteration, maxRetries, previousFeedback, feedbackHistory } = params.feedbackContext;
+      const feedbackBlock = [
+        `## Retry Feedback`,
+        `Attempt ${iteration} of ${maxRetries}. Your previous output was rejected.`,
+        '',
+        `### Latest Feedback`,
+        previousFeedback,
+        '',
+        ...(feedbackHistory.length > 1
+          ? [`### Feedback History`, ...feedbackHistory.map((f, i) => `${i + 1}. ${f}`)]
+          : []),
+      ].join('\n');
+      budget.add('feedback', feedbackBlock, 1);
+      this.logger.debug('Context section added', { section: 'feedback', charLength: feedbackBlock.length });
+    }
 
     // --- Priority 2: Upstream outputs ---
     if (upstreamOutputs?.length) {

--- a/src/dag/builder.ts
+++ b/src/dag/builder.ts
@@ -4,6 +4,7 @@ import type {
   DAGNode,
   DAGEdge,
   ConditionalEdge,
+  FeedbackEdge,
   Evaluator,
 } from '../types.js';
 
@@ -33,6 +34,7 @@ export class DAGBuilder {
   private nodes: Map<string, DAGNode> = new Map();
   private edges: DAGEdge[] = [];
   private conditionalEdges: ConditionalEdge[] = [];
+  private feedbackEdges: FeedbackEdge[] = [];
   private dynamicNodeIds: Set<string> = new Set();
 
   /** Add an agent node. Throws if a node with the same ID already exists. */
@@ -64,6 +66,12 @@ export class DAGBuilder {
       evaluate: config.evaluate,
       targets: config.targets,
     });
+    return this;
+  }
+
+  /** Add a feedback edge for retry loops with evaluation. */
+  feedbackEdge(config: FeedbackEdge): this {
+    this.feedbackEdges.push(config);
     return this;
   }
 
@@ -102,6 +110,19 @@ export class DAGBuilder {
       }
     }
 
+    // Validate feedback edges
+    for (const fe of this.feedbackEdges) {
+      if (!this.nodes.has(fe.from)) {
+        throw new Error(`Feedback edge references non-existent source node: "${fe.from}"`);
+      }
+      if (!this.nodes.has(fe.to)) {
+        throw new Error(`Feedback edge references non-existent target node: "${fe.to}"`);
+      }
+      if (fe.escalation?.reroute && !this.nodes.has(fe.escalation.reroute)) {
+        throw new Error(`Feedback edge escalation reroute references non-existent node: "${fe.escalation.reroute}"`);
+      }
+    }
+
     // Validate dynamic expansion node references
     for (const nodeId of this.dynamicNodeIds) {
       if (!this.nodes.has(nodeId)) {
@@ -122,6 +143,7 @@ export class DAGBuilder {
       nodes: Array.from(this.nodes.values()),
       edges: [...this.edges],
       conditionalEdges: [...this.conditionalEdges],
+      feedbackEdges: [...this.feedbackEdges],
       dynamicNodes: Array.from(this.dynamicNodeIds),
     };
   }

--- a/src/dag/builder.ts
+++ b/src/dag/builder.ts
@@ -14,6 +14,7 @@ export interface ConditionalEdgeConfig {
 
 export interface EdgeOptions {
   maxCycles?: number;
+  handoff?: string | import('../types.js').HandoffTemplate;
 }
 
 /**
@@ -48,6 +49,9 @@ export class DAGBuilder {
     const edge: DAGEdge = { from, to };
     if (options?.maxCycles !== undefined) {
       edge.maxCycles = options.maxCycles;
+    }
+    if (options?.handoff !== undefined) {
+      edge.handoff = options.handoff;
     }
     this.edges.push(edge);
     return this;

--- a/src/dag/executor.ts
+++ b/src/dag/executor.ts
@@ -1,4 +1,4 @@
-import type { SwarmEvent, NodeResult, CostSummary, ProviderAdapter, PersistenceAdapter, LifecycleHooks, EscalationPolicy } from '../types.js';
+import type { SwarmEvent, NodeResult, CostSummary, ProviderAdapter, PersistenceAdapter, LifecycleHooks, EscalationPolicy, Guard } from '../types.js';
 import type { AgentRunner } from '../agent/runner.js';
 import type { AgenticRunner } from '../agent/agentic-runner.js';
 import type { AgenticAdapter } from '../adapters/agentic/types.js';
@@ -7,6 +7,7 @@ import type { SwarmMemory } from '../memory/index.js';
 import { DAGGraph } from './graph.js';
 import { Scheduler } from './scheduler.js';
 import { evaluate } from '../agent/evaluator.js';
+import { runGuards } from '../guards/runner.js';
 import { Logger } from '../logger.js';
 import { getHandoffTemplate } from '../handoffs/templates.js';
 
@@ -47,6 +48,7 @@ export class DAGExecutor {
   private readonly lifecycle?: LifecycleHooks;
   private readonly dagId: string;
   private readonly logger: Logger;
+  private readonly defaultGuards: Guard[];
 
   /** Maps nodeId -> runId for persistence tracking. */
   private readonly runIds = new Map<string, string>();
@@ -78,6 +80,7 @@ export class DAGExecutor {
     persistence?: PersistenceAdapter,
     lifecycle?: LifecycleHooks,
     logger?: Logger,
+    defaultGuards?: Guard[],
   ) {
     this.graph = graph;
     this.runner = runner;
@@ -94,6 +97,7 @@ export class DAGExecutor {
     this.lifecycle = lifecycle;
     this.dagId = graph.id;
     this.logger = logger ?? new Logger();
+    this.defaultGuards = defaultGuards ?? [];
     this.startTime = Date.now();
 
     // Pre-compute the set of nodes that are targets of conditional edges.
@@ -336,6 +340,48 @@ export class DAGExecutor {
       }
 
       if (lastDoneEvent) {
+        // Run guards before marking completed
+        const nodeGuards = node.guards ?? (this.defaultGuards.length > 0 ? this.defaultGuards : undefined);
+        if (nodeGuards && nodeGuards.length > 0) {
+          const guardResults = await runGuards(
+            nodeGuards,
+            node.task ?? this.task,
+            lastDoneEvent.output,
+            this.provider,
+          );
+
+          let blocked = false;
+          for (const gr of guardResults) {
+            if (gr.triggered) {
+              if (gr.blocked) {
+                yield {
+                  type: 'guard_blocked' as const,
+                  nodeId,
+                  guardId: gr.guardId,
+                  guardType: gr.guardType,
+                  message: gr.message,
+                };
+                blocked = true;
+              } else {
+                yield {
+                  type: 'guard_warning' as const,
+                  nodeId,
+                  guardId: gr.guardId,
+                  guardType: gr.guardType,
+                  message: gr.message,
+                };
+              }
+            }
+          }
+
+          if (blocked) {
+            scheduler.markFailed(nodeId);
+            this.skipDownstream(nodeId, scheduler);
+            yield this.progressEvent(scheduler, completedNodeIds);
+            return;
+          }
+        }
+
         scheduler.markCompleted(nodeId);
         completedNodeIds.push(nodeId);
         outputs.set(nodeId, {
@@ -511,6 +557,47 @@ export class DAGExecutor {
         }
 
         if (lastDoneEvent) {
+          // Run guards before marking completed
+          const nodeGuards = node.guards ?? (this.defaultGuards.length > 0 ? this.defaultGuards : undefined);
+          if (nodeGuards && nodeGuards.length > 0) {
+            const guardResults = await runGuards(
+              nodeGuards,
+              node.task ?? this.task,
+              lastDoneEvent.output,
+              this.provider,
+            );
+
+            let blocked = false;
+            for (const gr of guardResults) {
+              if (gr.triggered) {
+                if (gr.blocked) {
+                  events.push({
+                    type: 'guard_blocked' as const,
+                    nodeId,
+                    guardId: gr.guardId,
+                    guardType: gr.guardType,
+                    message: gr.message,
+                  });
+                  blocked = true;
+                } else {
+                  events.push({
+                    type: 'guard_warning' as const,
+                    nodeId,
+                    guardId: gr.guardId,
+                    guardType: gr.guardType,
+                    message: gr.message,
+                  });
+                }
+              }
+            }
+
+            if (blocked) {
+              scheduler.markFailed(nodeId);
+              this.skipDownstream(nodeId, scheduler);
+              return { nodeId, events };
+            }
+          }
+
           scheduler.markCompleted(nodeId);
           completedNodeIds.push(nodeId);
           outputs.set(nodeId, {

--- a/src/dag/executor.ts
+++ b/src/dag/executor.ts
@@ -8,6 +8,7 @@ import { DAGGraph } from './graph.js';
 import { Scheduler } from './scheduler.js';
 import { evaluate } from '../agent/evaluator.js';
 import { Logger } from '../logger.js';
+import { getHandoffTemplate } from '../handoffs/templates.js';
 
 export interface ExecutorLimits {
   maxConcurrentAgents?: number;
@@ -257,6 +258,9 @@ export class DAGExecutor {
       this.logger.debug('Upstream outputs wired', { nodeId, upstreamNodeIds: upstreamOutputs.map(u => u.nodeId) });
     }
 
+    // Resolve handoff template from outgoing edges
+    const handoffTemplate = this.getNodeHandoffTemplate(nodeId);
+
     const startTime = Date.now();
 
     // Persistence: create run record
@@ -277,6 +281,7 @@ export class DAGExecutor {
             memory: this.memory,
             upstreamOutputs,
             signal: this.signal,
+            handoffTemplate,
           })
         : this.runner.run({
             nodeId,
@@ -285,6 +290,7 @@ export class DAGExecutor {
             memory: this.memory,
             upstreamOutputs,
             signal: this.signal,
+            handoffTemplate,
           });
 
       for await (const event of eventSource) {
@@ -420,6 +426,10 @@ export class DAGExecutor {
       }
 
       const upstreamOutputs = this.getUpstreamOutputs(nodeId, outputs);
+
+      // Resolve handoff template from outgoing edges
+      const handoffTemplate = this.getNodeHandoffTemplate(nodeId);
+
       const startTime = Date.now();
 
       // Persistence: create run record
@@ -438,6 +448,7 @@ export class DAGExecutor {
               memory: this.memory,
               upstreamOutputs,
               signal: this.signal,
+              handoffTemplate,
             })
           : this.runner.run({
               nodeId,
@@ -446,6 +457,7 @@ export class DAGExecutor {
               memory: this.memory,
               upstreamOutputs,
               signal: this.signal,
+              handoffTemplate,
             });
 
         for await (const event of eventSource) {
@@ -569,6 +581,20 @@ export class DAGExecutor {
 
     // Emit a single progress event after the entire parallel batch
     yield this.progressEvent(scheduler, completedNodeIds);
+  }
+
+  /**
+   * Resolve the handoff template from a node's outgoing edges.
+   * Returns the first resolved HandoffTemplate found, or undefined if none.
+   */
+  private getNodeHandoffTemplate(nodeId: string): import('../types.js').HandoffTemplate | undefined {
+    const outgoing = this.graph.getOutgoingEdges(nodeId);
+    for (const edge of outgoing) {
+      if (edge.handoff) {
+        return getHandoffTemplate(edge.handoff);
+      }
+    }
+    return undefined;
   }
 
   /**

--- a/src/dag/executor.ts
+++ b/src/dag/executor.ts
@@ -1,4 +1,4 @@
-import type { SwarmEvent, NodeResult, CostSummary, ProviderAdapter, PersistenceAdapter, LifecycleHooks } from '../types.js';
+import type { SwarmEvent, NodeResult, CostSummary, ProviderAdapter, PersistenceAdapter, LifecycleHooks, EscalationPolicy } from '../types.js';
 import type { AgentRunner } from '../agent/runner.js';
 import type { AgenticRunner } from '../agent/agentic-runner.js';
 import type { AgenticAdapter } from '../adapters/agentic/types.js';
@@ -53,6 +53,15 @@ export class DAGExecutor {
 
   /** Nodes that are targets of conditional edges and haven't been resolved yet. */
   private readonly conditionallyBlocked: Set<string> = new Set();
+
+  /** Feedback loop iteration counts keyed by "from->to". */
+  private readonly feedbackCounts = new Map<string, number>();
+
+  /** Feedback loop history of QA outputs keyed by "from->to". */
+  private readonly feedbackHistory = new Map<string, string[]>();
+
+  /** Pending feedback context to inject on next run of target node. */
+  private readonly pendingFeedback = new Map<string, import('../types.js').FeedbackContext>();
 
   constructor(
     graph: DAGGraph,
@@ -271,6 +280,12 @@ export class DAGExecutor {
     try {
       let lastDoneEvent: Extract<SwarmEvent, { type: 'agent_done' }> | null = null;
 
+      // Consume pending feedback context for this node (if any)
+      const feedbackContext = this.pendingFeedback.get(nodeId);
+      if (feedbackContext) {
+        this.pendingFeedback.delete(nodeId);
+      }
+
       const agenticCheck = this.isAgenticNode(nodeId);
       const eventSource = agenticCheck.isAgentic && this.agenticRunner
         ? this.agenticRunner.run({
@@ -282,6 +297,7 @@ export class DAGExecutor {
             upstreamOutputs,
             signal: this.signal,
             handoffTemplate,
+            feedbackContext,
           })
         : this.runner.run({
             nodeId,
@@ -291,6 +307,7 @@ export class DAGExecutor {
             upstreamOutputs,
             signal: this.signal,
             handoffTemplate,
+            feedbackContext,
           });
 
       for await (const event of eventSource) {
@@ -363,6 +380,9 @@ export class DAGExecutor {
 
         // Handle cycle edges originating from this node
         yield* this.handleCycleEdges(nodeId, scheduler);
+
+        // Handle feedback edges originating from this node
+        yield* this.handleFeedbackEdges(nodeId, lastDoneEvent.output, scheduler);
 
         // Handle dynamic DAG expansion
         if (node.canEmitDAG) {
@@ -438,6 +458,12 @@ export class DAGExecutor {
       try {
         let lastDoneEvent: Extract<SwarmEvent, { type: 'agent_done' }> | null = null;
 
+        // Consume pending feedback context for this node (if any)
+        const feedbackContext = this.pendingFeedback.get(nodeId);
+        if (feedbackContext) {
+          this.pendingFeedback.delete(nodeId);
+        }
+
         const agenticCheck = this.isAgenticNode(nodeId);
         const eventSource = agenticCheck.isAgentic && this.agenticRunner
           ? this.agenticRunner.run({
@@ -449,6 +475,7 @@ export class DAGExecutor {
               upstreamOutputs,
               signal: this.signal,
               handoffTemplate,
+              feedbackContext,
             })
           : this.runner.run({
               nodeId,
@@ -458,6 +485,7 @@ export class DAGExecutor {
               upstreamOutputs,
               signal: this.signal,
               handoffTemplate,
+              feedbackContext,
             });
 
         for await (const event of eventSource) {
@@ -533,6 +561,11 @@ export class DAGExecutor {
           // Handle cycle edges originating from this node
           for await (const cycleEvent of this.handleCycleEdges(nodeId, scheduler)) {
             events.push(cycleEvent);
+          }
+
+          // Handle feedback edges originating from this node
+          for await (const fbEvent of this.handleFeedbackEdges(nodeId, lastDoneEvent.output, scheduler)) {
+            events.push(fbEvent);
           }
 
           // Handle dynamic DAG expansion
@@ -786,6 +819,93 @@ export class DAGExecutor {
 
       if (iteration < edge.maxCycles) {
         scheduler.resetNodeForCycle(nodeId);
+      }
+    }
+  }
+
+  /**
+   * Handle feedback edges originating from a completed node.
+   *
+   * After a QA-like node completes, its output is evaluated against the feedback
+   * edge's evaluator. If the output passes, the loop ends and downstream continues.
+   * If it fails, the target node (and this QA node) are reset for retry, with
+   * feedback context injected into the target's next run. After maxRetries
+   * exhausted, the escalation policy determines what happens.
+   */
+  private async *handleFeedbackEdges(
+    nodeId: string,
+    output: string,
+    scheduler: Scheduler,
+  ): AsyncGenerator<SwarmEvent> {
+    const feedbackEdges = this.graph.getFeedbackEdges(nodeId);
+    if (feedbackEdges.length === 0) return;
+
+    for (const fe of feedbackEdges) {
+      // Evaluate: did the output pass?
+      const evalProvider = (fe.evaluate.type === 'llm' && fe.evaluate.providerId)
+        ? (this.providers.get(fe.evaluate.providerId) ?? this.provider)
+        : this.provider;
+
+      const result = await evaluate(fe.evaluate, output, evalProvider);
+
+      if (result === fe.passLabel) {
+        // Passed — feedback loop ends, downstream proceeds normally
+        this.logger.info('Feedback loop passed', { from: nodeId, to: fe.to, result });
+        continue;
+      }
+
+      // Failed — check retry count
+      const key = `${fe.from}->${fe.to}`;
+      const count = (this.feedbackCounts.get(key) ?? 0) + 1;
+      this.feedbackCounts.set(key, count);
+
+      // Track feedback history
+      const history = this.feedbackHistory.get(key) ?? [];
+      history.push(output);
+      this.feedbackHistory.set(key, history);
+
+      if (count >= fe.maxRetries) {
+        // Escalate
+        const policy: EscalationPolicy = fe.escalation ?? { action: 'fail' as const };
+        yield {
+          type: 'feedback_escalation',
+          fromNode: fe.from,
+          toNode: fe.to,
+          policy,
+          iteration: count,
+        };
+        this.logger.warn('Feedback loop escalated', { from: fe.from, to: fe.to, iteration: count });
+
+        if (policy.action === 'fail') {
+          scheduler.markFailed(fe.to);
+          this.skipDownstream(fe.to, scheduler);
+        } else if (policy.action === 'skip') {
+          scheduler.markSkipped(fe.to);
+        } else if (policy.action === 'reroute' && policy.reroute) {
+          this.conditionallyBlocked.delete(policy.reroute);
+        }
+      } else {
+        // Retry: reset target node AND this (QA) node so the loop can repeat
+        yield {
+          type: 'feedback_retry',
+          fromNode: fe.from,
+          toNode: fe.to,
+          iteration: count,
+          maxRetries: fe.maxRetries,
+        };
+        this.logger.info('Feedback retry', { from: fe.from, to: fe.to, iteration: count, maxRetries: fe.maxRetries });
+
+        // Reset both the target node (dev) AND the QA node so the loop repeats
+        scheduler.resetNodeForCycle(fe.to);
+        scheduler.resetNodeForCycle(fe.from);
+
+        // Store feedback context for the target node's next run
+        this.pendingFeedback.set(fe.to, {
+          iteration: count,
+          maxRetries: fe.maxRetries,
+          previousFeedback: output,
+          feedbackHistory: [...history],
+        });
       }
     }
   }

--- a/src/dag/graph.ts
+++ b/src/dag/graph.ts
@@ -1,4 +1,4 @@
-import type { DAGDefinition, DAGNode, DAGEdge, ConditionalEdge } from '../types.js';
+import type { DAGDefinition, DAGNode, DAGEdge, ConditionalEdge, FeedbackEdge } from '../types.js';
 
 /**
  * Runtime wrapper around a DAGDefinition providing traversal helpers.
@@ -7,6 +7,7 @@ export class DAGGraph {
   nodes: DAGNode[];
   edges: DAGEdge[];
   readonly conditionalEdges: ConditionalEdge[];
+  readonly feedbackEdges: FeedbackEdge[];
   readonly dynamicNodes: string[];
   readonly id: string;
 
@@ -15,6 +16,7 @@ export class DAGGraph {
     this.nodes = definition.nodes;
     this.edges = definition.edges;
     this.conditionalEdges = definition.conditionalEdges;
+    this.feedbackEdges = definition.feedbackEdges ?? [];
     this.dynamicNodes = definition.dynamicNodes;
   }
 
@@ -36,6 +38,11 @@ export class DAGGraph {
   /** Return all conditional edges originating from the given node. */
   getConditionalEdges(nodeId: string): ConditionalEdge[] {
     return this.conditionalEdges.filter((e) => e.from === nodeId);
+  }
+
+  /** Return all feedback edges originating from the given node. */
+  getFeedbackEdges(fromNodeId: string): FeedbackEdge[] {
+    return this.feedbackEdges.filter(fe => fe.from === fromNodeId);
   }
 
   /** Return root nodes -- nodes with no incoming edges. */

--- a/src/dag/validator.ts
+++ b/src/dag/validator.ts
@@ -141,7 +141,22 @@ export function validateDAG(
     }
   }
 
-  // 1c. Regular edge endpoint validation
+  // 1c. Feedback edge validation
+  if (dag.feedbackEdges) {
+    for (const fe of dag.feedbackEdges) {
+      if (!nodeIds.has(fe.from)) {
+        errors.push(`Feedback edge source "${fe.from}" does not exist in the DAG`);
+      }
+      if (!nodeIds.has(fe.to)) {
+        errors.push(`Feedback edge target "${fe.to}" does not exist in the DAG`);
+      }
+      if (fe.escalation?.reroute && !nodeIds.has(fe.escalation.reroute)) {
+        errors.push(`Feedback edge escalation reroute "${fe.escalation.reroute}" does not exist in the DAG`);
+      }
+    }
+  }
+
+  // 1d. Regular edge endpoint validation
   for (const edge of dag.edges) {
     if (!nodeIds.has(edge.from)) {
       errors.push(`Edge source "${edge.from}" does not exist in the DAG`);
@@ -185,6 +200,19 @@ export function validateDAG(
           errors.push(
             `Conditional edge from "${ce.from}" references provider "${ce.evaluate.providerId}" which does not exist in config`,
           );
+        }
+      }
+    }
+
+    // Also check feedback edge evaluators that reference providers
+    if (dag.feedbackEdges) {
+      for (const fe of dag.feedbackEdges) {
+        if (fe.evaluate.type === 'llm' && fe.evaluate.providerId !== undefined) {
+          if (!(fe.evaluate.providerId in providers)) {
+            errors.push(
+              `Feedback edge from "${fe.from}" references provider "${fe.evaluate.providerId}" which does not exist in config`,
+            );
+          }
         }
       }
     }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -200,6 +200,7 @@ export class SwarmEngine {
       this.persistence,
       this.config.lifecycle,
       this.logger,
+      this.config.guards,
     );
 
     // 9. Yield all events from executor

--- a/src/guards/evidence.ts
+++ b/src/guards/evidence.ts
@@ -1,0 +1,53 @@
+export interface EvidenceResult {
+  triggered: boolean;
+  claims: string[];
+  message: string;
+}
+
+const CLAIM_PATTERNS = [
+  /all tests pass/i,
+  /no issues found/i,
+  /works correctly/i,
+  /verified successfully/i,
+  /no errors/i,
+  /no bugs/i,
+  /fully functional/i,
+  /everything works/i,
+  /all checks pass/i,
+];
+
+const EVIDENCE_PATTERNS = [
+  /```[\s\S]*?```/,                   // code blocks
+  /\$\s+\S+/,                         // shell commands ($ command)
+  /[a-zA-Z_/][a-zA-Z0-9_/.-]*\.[a-zA-Z]{1,5}/,  // file paths
+  /✓|✗|PASS|FAIL|passed|failed/,      // test result indicators
+  /\d+\s+(tests?|specs?|assertions?)\s+(passed|failed)/i, // test counts
+  /Error:|Warning:|Exception:/i,       // error outputs
+];
+
+export function evidenceGuard(output: string): EvidenceResult {
+  const matchedClaims: string[] = [];
+
+  for (const pattern of CLAIM_PATTERNS) {
+    const match = output.match(pattern);
+    if (match) {
+      matchedClaims.push(match[0].toLowerCase());
+    }
+  }
+
+  if (matchedClaims.length === 0) {
+    return { triggered: false, claims: [], message: '' };
+  }
+
+  const hasEvidence = EVIDENCE_PATTERNS.some(pattern => pattern.test(output));
+
+  if (hasEvidence) {
+    return { triggered: false, claims: matchedClaims, message: '' };
+  }
+
+  return {
+    triggered: true,
+    claims: matchedClaims,
+    message: `Claims without evidence: ${matchedClaims.join(', ')}. Output should include supporting evidence (test output, file paths, command results).`,
+  };
+}

--- a/src/guards/runner.ts
+++ b/src/guards/runner.ts
@@ -1,0 +1,69 @@
+import type { Guard, ProviderAdapter } from '../types.js';
+import { evidenceGuard } from './evidence.js';
+import { scopeCreepGuard } from './scope-creep.js';
+
+export interface GuardResult {
+  guardId: string;
+  guardType: string;
+  triggered: boolean;
+  blocked: boolean;
+  skipped?: boolean;
+  message: string;
+}
+
+/**
+ * Run all guards against a node's output.
+ * Evidence guards run first (fast, pattern-based).
+ * Scope-creep guards run second (requires LLM).
+ */
+export async function runGuards(
+  guards: Guard[],
+  task: string,
+  output: string,
+  provider?: ProviderAdapter,
+): Promise<GuardResult[]> {
+  if (guards.length === 0) return [];
+
+  // Sort: evidence first, then scope-creep, then others
+  const sorted = [...guards].sort((a, b) => {
+    const order: Record<string, number> = { evidence: 0, 'scope-creep': 1 };
+    return (order[a.type] ?? 2) - (order[b.type] ?? 2);
+  });
+
+  const results: GuardResult[] = [];
+
+  for (const guard of sorted) {
+    if (guard.type === 'evidence') {
+      const result = evidenceGuard(output);
+      results.push({
+        guardId: guard.id,
+        guardType: guard.type,
+        triggered: result.triggered,
+        blocked: result.triggered && guard.mode === 'block',
+        message: result.message,
+      });
+    } else if (guard.type === 'scope-creep') {
+      if (!provider) {
+        results.push({
+          guardId: guard.id,
+          guardType: guard.type,
+          triggered: false,
+          blocked: false,
+          skipped: true,
+          message: 'Scope creep guard skipped: no provider available',
+        });
+        continue;
+      }
+      const result = await scopeCreepGuard(task, output, provider);
+      results.push({
+        guardId: guard.id,
+        guardType: guard.type,
+        triggered: result.triggered,
+        blocked: result.triggered && guard.mode === 'block',
+        message: result.message,
+      });
+    }
+  }
+
+  return results;
+}

--- a/src/guards/scope-creep.ts
+++ b/src/guards/scope-creep.ts
@@ -1,0 +1,48 @@
+import type { ProviderAdapter } from '../types.js';
+
+export interface ScopeCreepResult {
+  triggered: boolean;
+  message: string;
+}
+
+export async function scopeCreepGuard(
+  task: string,
+  output: string,
+  provider: ProviderAdapter,
+): Promise<ScopeCreepResult> {
+  if (!provider) {
+    throw new Error('Scope creep guard requires a provider');
+  }
+
+  let result = '';
+  for await (const event of provider.stream({
+    model: 'default',
+    messages: [
+      {
+        role: 'system',
+        content: 'You evaluate whether an agent\'s output stays within scope of its task. Return ONLY "SCOPED" if the output addresses only what was asked, or "OVERSCOPED: <one-line reason>" if the output contains work beyond the task.',
+      },
+      {
+        role: 'user',
+        content: `Task: ${task}\n\nOutput:\n${output.slice(0, 3000)}`,
+      },
+    ],
+    temperature: 0,
+    maxTokens: 100,
+  })) {
+    if (event.type === 'chunk') {
+      result += event.content;
+    }
+  }
+
+  const trimmed = result.trim();
+
+  if (trimmed.startsWith('SCOPED') && !trimmed.startsWith('OVERSCOPED')) {
+    return { triggered: false, message: '' };
+  }
+
+  return {
+    triggered: true,
+    message: trimmed,
+  };
+}

--- a/src/handoffs/formatter.ts
+++ b/src/handoffs/formatter.ts
@@ -23,6 +23,10 @@ export function formatHandoffInstructions(template: HandoffTemplate): string {
  * Format a node's raw output for downstream consumption.
  * Wraps with agent identity header. The raw output is passed through —
  * the template was used to shape it at generation time, not parse it after.
+ *
+ * Note: Not used internally by the engine (upstream outputs are formatted
+ * inline by ContextAssembler). Exported as a consumer utility for applications
+ * that need to format handoff outputs outside the engine pipeline.
  */
 export function formatHandoffOutput(
   _template: HandoffTemplate,

--- a/src/handoffs/formatter.ts
+++ b/src/handoffs/formatter.ts
@@ -1,0 +1,34 @@
+import type { HandoffTemplate } from '../types.js';
+
+/**
+ * Generate output formatting instructions to inject into a producing agent's
+ * system prompt so it structures its output with the template's sections.
+ */
+export function formatHandoffInstructions(template: HandoffTemplate): string {
+  const lines = [
+    '## Output Format',
+    'Structure your output with the following sections:',
+    '',
+  ];
+  for (const section of template.sections) {
+    const req = section.required ? ' (REQUIRED)' : '';
+    lines.push(`## ${section.label}${req}`);
+    lines.push(`[Your ${section.label.toLowerCase()} here]`);
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Format a node's raw output for downstream consumption.
+ * Wraps with agent identity header. The raw output is passed through —
+ * the template was used to shape it at generation time, not parse it after.
+ */
+export function formatHandoffOutput(
+  _template: HandoffTemplate,
+  rawOutput: string,
+  agentRole: string,
+  nodeId: string,
+): string {
+  return `### Output from ${agentRole} (${nodeId})\n${rawOutput}`;
+}

--- a/src/handoffs/templates.ts
+++ b/src/handoffs/templates.ts
@@ -1,0 +1,52 @@
+import type { HandoffTemplate } from '../types.js';
+
+export const HANDOFF_PRESETS: Record<string, HandoffTemplate> = {
+  standard: {
+    id: 'standard',
+    sections: [
+      { key: 'summary', label: 'Summary', required: true },
+      { key: 'deliverables', label: 'Deliverables', required: true },
+      { key: 'context_for_next', label: 'Context for Next Step' },
+    ],
+  },
+  'qa-review': {
+    id: 'qa-review',
+    sections: [
+      { key: 'deliverables', label: 'Deliverables', required: true },
+      { key: 'test_criteria', label: 'Test Criteria', required: true },
+      { key: 'known_limitations', label: 'Known Limitations' },
+    ],
+  },
+  'qa-feedback': {
+    id: 'qa-feedback',
+    sections: [
+      { key: 'verdict', label: 'Verdict', required: true },
+      { key: 'issues_found', label: 'Issues Found', required: true },
+      { key: 'suggestions', label: 'Suggestions' },
+    ],
+  },
+  escalation: {
+    id: 'escalation',
+    sections: [
+      { key: 'problem_description', label: 'Problem Description', required: true },
+      { key: 'attempts_made', label: 'Attempts Made', required: true },
+      { key: 'recommendation', label: 'Recommendation', required: true },
+    ],
+  },
+};
+
+/**
+ * Resolve a handoff reference to a HandoffTemplate.
+ * If `ref` is a string, look up the preset by name. If it's already a
+ * HandoffTemplate object, return it as-is.
+ */
+export function getHandoffTemplate(ref: string | HandoffTemplate): HandoffTemplate {
+  if (typeof ref !== 'string') {
+    return ref;
+  }
+  const preset = HANDOFF_PRESETS[ref];
+  if (!preset) {
+    throw new Error(`Unknown handoff preset: "${ref}"`);
+  }
+  return preset;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,5 +51,17 @@ export type {
 // Logging
 export { Logger } from './logger.js';
 
+// Handoffs
+export { HANDOFF_PRESETS, getHandoffTemplate } from './handoffs/templates.js';
+export { formatHandoffInstructions, formatHandoffOutput } from './handoffs/formatter.js';
+
+// Guards
+export { runGuards } from './guards/runner.js';
+export type { GuardResult } from './guards/runner.js';
+export { evidenceGuard } from './guards/evidence.js';
+export type { EvidenceResult } from './guards/evidence.js';
+export { scopeCreepGuard } from './guards/scope-creep.js';
+export type { ScopeCreepResult } from './guards/scope-creep.js';
+
 // Types
 export type * from './types.js';

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,6 +132,18 @@ export interface DAGEdge {
   from: string;
   to: string;
   maxCycles?: number;
+  handoff?: string | HandoffTemplate;
+}
+
+export interface HandoffTemplate {
+  id: string;
+  sections: HandoffSection[];
+}
+
+export interface HandoffSection {
+  key: string;
+  label: string;
+  required?: boolean;
 }
 
 export interface ConditionalEdge {

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,7 +83,9 @@ export type SwarmEvent =
   | { type: 'route_decision'; fromNode: string; toNode: string; reason: string }
   | { type: 'loop_iteration'; nodeId: string; iteration: number; maxIterations: number }
   | { type: 'budget_warning'; used: number; limit: number; percentUsed: number }
-  | { type: 'budget_exceeded'; used: number; limit: number };
+  | { type: 'budget_exceeded'; used: number; limit: number }
+  | { type: 'feedback_retry'; fromNode: string; toNode: string; iteration: number; maxRetries: number }
+  | { type: 'feedback_escalation'; fromNode: string; toNode: string; policy: EscalationPolicy; iteration: number };
 
 export type AgentErrorType =
   | 'timeout'

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,7 +85,9 @@ export type SwarmEvent =
   | { type: 'budget_warning'; used: number; limit: number; percentUsed: number }
   | { type: 'budget_exceeded'; used: number; limit: number }
   | { type: 'feedback_retry'; fromNode: string; toNode: string; iteration: number; maxRetries: number }
-  | { type: 'feedback_escalation'; fromNode: string; toNode: string; policy: EscalationPolicy; iteration: number };
+  | { type: 'feedback_escalation'; fromNode: string; toNode: string; policy: EscalationPolicy; iteration: number }
+  | { type: 'guard_warning'; nodeId: string; guardId: string; guardType: string; message: string }
+  | { type: 'guard_blocked'; nodeId: string; guardId: string; guardType: string; message: string };
 
 export type AgentErrorType =
   | 'timeout'
@@ -128,6 +130,7 @@ export interface DAGNode {
   agent: AgentDescriptor;
   task?: string;
   canEmitDAG?: boolean;
+  guards?: Guard[];
 }
 
 export interface DAGEdge {
@@ -170,6 +173,13 @@ export interface EscalationPolicy {
   message?: string;
 }
 
+export interface Guard {
+  id: string;
+  type: 'scope-creep' | 'evidence' | string;
+  mode: 'warn' | 'block';
+  config?: Record<string, unknown>;
+}
+
 export interface ConditionalEdge {
   from: string;
   evaluate: Evaluator;
@@ -210,6 +220,7 @@ export interface SwarmEngineConfig {
   defaults?: EngineDefaults;
   limits?: EngineLimits;
   logging?: LoggingConfig;
+  guards?: Guard[];
 }
 
 export interface EngineDefaults {

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,6 +146,13 @@ export interface HandoffSection {
   required?: boolean;
 }
 
+export interface FeedbackContext {
+  iteration: number;
+  maxRetries: number;
+  previousFeedback: string;
+  feedbackHistory: string[];
+}
+
 export interface ConditionalEdge {
   from: string;
   evaluate: Evaluator;

--- a/src/types.ts
+++ b/src/types.ts
@@ -153,6 +153,21 @@ export interface FeedbackContext {
   feedbackHistory: string[];
 }
 
+export interface FeedbackEdge {
+  from: string;
+  to: string;
+  maxRetries: number;
+  evaluate: Evaluator;
+  passLabel: string;
+  escalation?: EscalationPolicy;
+}
+
+export interface EscalationPolicy {
+  action: 'skip' | 'fail' | 'reroute';
+  reroute?: string;
+  message?: string;
+}
+
 export interface ConditionalEdge {
   from: string;
   evaluate: Evaluator;
@@ -313,6 +328,7 @@ export interface DAGDefinition {
   nodes: DAGNode[];
   edges: DAGEdge[];
   conditionalEdges: ConditionalEdge[];
+  feedbackEdges: FeedbackEdge[];
   dynamicNodes: string[];
 }
 

--- a/tests/context/assembler.test.ts
+++ b/tests/context/assembler.test.ts
@@ -152,4 +152,122 @@ describe('ContextAssembler', () => {
     const assembledLog = debugLogs.find(l => l.message.includes('Context assembled'));
     expect(assembledLog?.context?.sections).toBeGreaterThanOrEqual(2);
   });
+
+  describe('handoff instructions', () => {
+    it('injects handoff formatting instructions into system prompt', async () => {
+      const assembler = new ContextAssembler({
+        context: new NoopContextProvider(),
+        memory: new NoopMemoryProvider(),
+        codebase: new NoopCodebaseProvider(),
+        persona: new NoopPersonaProvider(),
+      });
+
+      const template = {
+        id: 'test',
+        sections: [{ key: 'summary', label: 'Summary', required: true }],
+      };
+
+      const messages = await assembler.assemble({
+        systemPrompt: 'You are a developer.',
+        task: 'Build a feature',
+        contextWindow: 100000,
+        handoffTemplate: template,
+      });
+
+      const systemContent = messages.find(m => m.role === 'system')!.content;
+      expect(systemContent).toContain('## Output Format');
+      expect(systemContent).toContain('## Summary (REQUIRED)');
+    });
+
+    it('does not inject instructions when no handoff template provided', async () => {
+      const assembler = new ContextAssembler({
+        context: new NoopContextProvider(),
+        memory: new NoopMemoryProvider(),
+        codebase: new NoopCodebaseProvider(),
+        persona: new NoopPersonaProvider(),
+      });
+
+      const messages = await assembler.assemble({
+        systemPrompt: 'You are a developer.',
+        task: 'Build a feature',
+        contextWindow: 100000,
+      });
+
+      const systemContent = messages.find(m => m.role === 'system')!.content;
+      expect(systemContent).not.toContain('## Output Format');
+    });
+  });
+
+  describe('feedback context', () => {
+    it('injects feedback context at high priority', async () => {
+      const assembler = new ContextAssembler({
+        context: new NoopContextProvider(),
+        memory: new NoopMemoryProvider(),
+        codebase: new NoopCodebaseProvider(),
+        persona: new NoopPersonaProvider(),
+      });
+
+      const messages = await assembler.assemble({
+        systemPrompt: 'You are a developer.',
+        task: 'Build a feature',
+        contextWindow: 100000,
+        feedbackContext: {
+          iteration: 2,
+          maxRetries: 3,
+          previousFeedback: 'Missing error handling in the auth module.',
+          feedbackHistory: ['Incomplete implementation.', 'Missing error handling in the auth module.'],
+        },
+      });
+
+      const systemContent = messages.find(m => m.role === 'system')!.content;
+      expect(systemContent).toContain('## Retry Feedback');
+      expect(systemContent).toContain('Attempt 2 of 3');
+      expect(systemContent).toContain('Missing error handling in the auth module.');
+    });
+
+    it('does not inject feedback when not provided', async () => {
+      const assembler = new ContextAssembler({
+        context: new NoopContextProvider(),
+        memory: new NoopMemoryProvider(),
+        codebase: new NoopCodebaseProvider(),
+        persona: new NoopPersonaProvider(),
+      });
+
+      const messages = await assembler.assemble({
+        systemPrompt: 'You are a developer.',
+        task: 'Build a feature',
+        contextWindow: 100000,
+      });
+
+      const systemContent = messages.find(m => m.role === 'system')!.content;
+      expect(systemContent).not.toContain('## Retry Feedback');
+    });
+
+    it('includes feedback history when multiple attempts', async () => {
+      const assembler = new ContextAssembler({
+        context: new NoopContextProvider(),
+        memory: new NoopMemoryProvider(),
+        codebase: new NoopCodebaseProvider(),
+        persona: new NoopPersonaProvider(),
+      });
+
+      const messages = await assembler.assemble({
+        systemPrompt: 'You are a developer.',
+        task: 'Build a feature',
+        contextWindow: 100000,
+        feedbackContext: {
+          iteration: 3,
+          maxRetries: 5,
+          previousFeedback: 'Still missing validation.',
+          feedbackHistory: ['No tests.', 'Missing auth.', 'Still missing validation.'],
+        },
+      });
+
+      const systemContent = messages.find(m => m.role === 'system')!.content;
+      expect(systemContent).toContain('### Feedback History');
+      expect(systemContent).toContain('1. No tests.');
+      expect(systemContent).toContain('2. Missing auth.');
+      expect(systemContent).toContain('3. Still missing validation.');
+    });
+  });
 });

--- a/tests/dag/builder.test.ts
+++ b/tests/dag/builder.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { DAGBuilder } from '../../src/dag/builder.js';
+import type { AgentDescriptor } from '../../src/types.js';
+
+function agent(id: string): AgentDescriptor {
+  return { id, name: id, role: id, systemPrompt: '' };
+}
 
 describe('DAGBuilder', () => {
   it('builds a sequential DAG', () => {
@@ -69,5 +74,38 @@ describe('DAGBuilder', () => {
       .build();
 
     expect(dag.dynamicNodes).toContain('coordinator');
+  });
+
+  describe('edge with handoff', () => {
+    it('stores handoff preset name on edge', () => {
+      const dag = new DAGBuilder()
+        .agent('a', agent('a'))
+        .agent('b', agent('b'))
+        .edge('a', 'b', { handoff: 'standard' })
+        .build();
+
+      expect(dag.edges[0].handoff).toBe('standard');
+    });
+
+    it('stores inline handoff template on edge', () => {
+      const inline = { id: 'custom', sections: [{ key: 'x', label: 'X' }] };
+      const dag = new DAGBuilder()
+        .agent('a', agent('a'))
+        .agent('b', agent('b'))
+        .edge('a', 'b', { handoff: inline })
+        .build();
+
+      expect(dag.edges[0].handoff).toEqual(inline);
+    });
+
+    it('edge without handoff has no handoff field', () => {
+      const dag = new DAGBuilder()
+        .agent('a', agent('a'))
+        .agent('b', agent('b'))
+        .edge('a', 'b')
+        .build();
+
+      expect(dag.edges[0].handoff).toBeUndefined();
+    });
   });
 });

--- a/tests/dag/executor-guards.test.ts
+++ b/tests/dag/executor-guards.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest';
+import { DAGBuilder } from '../../src/dag/builder.js';
+import { DAGGraph } from '../../src/dag/graph.js';
+import { DAGExecutor } from '../../src/dag/executor.js';
+import { CostTracker } from '../../src/cost/tracker.js';
+import { SwarmMemory } from '../../src/memory/index.js';
+import type { SwarmEvent, CostSummary, Guard } from '../../src/types.js';
+
+function agent(id: string) {
+  return { id, name: id, role: id, systemPrompt: '' };
+}
+function emptyCost(): CostSummary {
+  return { inputTokens: 0, outputTokens: 0, totalTokens: 0, costCents: 0, calls: 0 };
+}
+
+function createMockRunner(outputMap: Record<string, string>) {
+  return {
+    async *run(params: any): AsyncGenerator<SwarmEvent> {
+      const output = outputMap[params.nodeId] ?? `output-${params.nodeId}`;
+      yield { type: 'agent_start', nodeId: params.nodeId, agentRole: params.agent.role, agentName: params.agent.name };
+      yield { type: 'agent_done', nodeId: params.nodeId, agentRole: params.agent.role, output, cost: emptyCost() };
+    },
+  };
+}
+
+describe('executor guard integration', () => {
+  it('emits guard_warning for evidence guard in warn mode', async () => {
+    const runner = createMockRunner({ dev: 'All tests pass and everything works correctly.' });
+
+    const dag = new DAGBuilder()
+      .agent('dev', agent('dev'))
+      .build();
+
+    // Set guards on the node directly
+    dag.nodes[0].guards = [{ id: 'ev', type: 'evidence', mode: 'warn' as const }];
+
+    const graph = new DAGGraph(dag);
+    const executor = new DAGExecutor(
+      graph, runner as any, new CostTracker(null, null),
+      new SwarmMemory(), 'test task',
+    );
+
+    const events: SwarmEvent[] = [];
+    for await (const event of executor.execute()) {
+      events.push(event);
+    }
+
+    const warning = events.find(e => e.type === 'guard_warning');
+    expect(warning).toBeDefined();
+    expect(warning).toMatchObject({ nodeId: 'dev', guardId: 'ev', guardType: 'evidence' });
+    // Node should still complete (warn mode)
+    expect(events.find(e => e.type === 'swarm_done')).toBeDefined();
+  });
+
+  it('blocks node for evidence guard in block mode', async () => {
+    const runner = createMockRunner({ dev: 'All tests pass.' });
+
+    const dag = new DAGBuilder()
+      .agent('dev', agent('dev'))
+      .agent('next', agent('next'))
+      .edge('dev', 'next')
+      .build();
+
+    dag.nodes[0].guards = [{ id: 'ev', type: 'evidence', mode: 'block' as const }];
+
+    const graph = new DAGGraph(dag);
+    const executor = new DAGExecutor(
+      graph, runner as any, new CostTracker(null, null),
+      new SwarmMemory(), 'test task',
+    );
+
+    const events: SwarmEvent[] = [];
+    for await (const event of executor.execute()) {
+      events.push(event);
+    }
+
+    const blocked = events.find(e => e.type === 'guard_blocked');
+    expect(blocked).toBeDefined();
+    // Downstream node should be skipped
+    expect(events.find(e => e.type === 'swarm_done')).toBeDefined();
+    // The 'next' node should NOT have started since 'dev' was blocked
+    const nextStart = events.find(e => e.type === 'agent_start' && (e as any).nodeId === 'next');
+    expect(nextStart).toBeUndefined();
+  });
+
+  it('uses engine-wide default guards when node has none', async () => {
+    const runner = createMockRunner({ dev: 'All tests pass.' });
+
+    const dag = new DAGBuilder()
+      .agent('dev', agent('dev'))
+      .build();
+
+    const graph = new DAGGraph(dag);
+    const defaultGuards: Guard[] = [{ id: 'ev', type: 'evidence', mode: 'warn' }];
+
+    const executor = new DAGExecutor(
+      graph, runner as any, new CostTracker(null, null),
+      new SwarmMemory(), 'test task',
+      undefined, // signal
+      undefined, // provider
+      undefined, // providers
+      undefined, // limits
+      undefined, // agenticRunner
+      undefined, // agenticAdapters
+      undefined, // persistence
+      undefined, // lifecycle
+      undefined, // logger
+      defaultGuards, // defaultGuards
+    );
+
+    const events: SwarmEvent[] = [];
+    for await (const event of executor.execute()) {
+      events.push(event);
+    }
+
+    const warning = events.find(e => e.type === 'guard_warning');
+    expect(warning).toBeDefined();
+  });
+
+  it('does not trigger guards when output has evidence', async () => {
+    const runner = createMockRunner({
+      dev: 'All tests pass.\n\n```\n$ npm test\n✓ 42 tests passed\n```',
+    });
+
+    const dag = new DAGBuilder()
+      .agent('dev', agent('dev'))
+      .build();
+
+    dag.nodes[0].guards = [{ id: 'ev', type: 'evidence', mode: 'block' as const }];
+
+    const graph = new DAGGraph(dag);
+    const executor = new DAGExecutor(
+      graph, runner as any, new CostTracker(null, null),
+      new SwarmMemory(), 'test task',
+    );
+
+    const events: SwarmEvent[] = [];
+    for await (const event of executor.execute()) {
+      events.push(event);
+    }
+
+    // No guard events since evidence was present
+    expect(events.find(e => e.type === 'guard_warning')).toBeUndefined();
+    expect(events.find(e => e.type === 'guard_blocked')).toBeUndefined();
+    expect(events.find(e => e.type === 'swarm_done')).toBeDefined();
+  });
+
+  it('node-level guards override engine-wide defaults', async () => {
+    const runner = createMockRunner({ dev: 'All tests pass.' });
+
+    const dag = new DAGBuilder()
+      .agent('dev', agent('dev'))
+      .build();
+
+    // Node has a warn-mode guard (should warn, not block)
+    dag.nodes[0].guards = [{ id: 'node-ev', type: 'evidence', mode: 'warn' as const }];
+
+    // Engine default would block
+    const defaultGuards: Guard[] = [{ id: 'engine-ev', type: 'evidence', mode: 'block' }];
+
+    const graph = new DAGGraph(dag);
+    const executor = new DAGExecutor(
+      graph, runner as any, new CostTracker(null, null),
+      new SwarmMemory(), 'test task',
+      undefined, undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined,
+      undefined,
+      defaultGuards,
+    );
+
+    const events: SwarmEvent[] = [];
+    for await (const event of executor.execute()) {
+      events.push(event);
+    }
+
+    // Should use node-level guard (warn), not engine default (block)
+    const warning = events.find(e => e.type === 'guard_warning');
+    expect(warning).toBeDefined();
+    expect((warning as any).guardId).toBe('node-ev');
+    // Should NOT be blocked
+    expect(events.find(e => e.type === 'guard_blocked')).toBeUndefined();
+    expect(events.find(e => e.type === 'swarm_done')).toBeDefined();
+  });
+});

--- a/tests/dag/executor.test.ts
+++ b/tests/dag/executor.test.ts
@@ -896,6 +896,114 @@ describe('DAGExecutor', () => {
     });
   });
 
+  describe('handoff template wiring', () => {
+    it('passes handoff template from outgoing edge to runner', async () => {
+      let capturedHandoff: unknown = undefined;
+
+      const mockRunner = {
+        async *run(params: any): AsyncGenerator<SwarmEvent> {
+          if (params.nodeId === 'a') {
+            capturedHandoff = params.handoffTemplate;
+          }
+          yield { type: 'agent_start', nodeId: params.nodeId, agentRole: params.agent.role, agentName: params.agent.name };
+          yield { type: 'agent_done', nodeId: params.nodeId, agentRole: params.agent.role, output: `output-${params.nodeId}`, cost: emptyCost() };
+        },
+      } as AgentRunner;
+
+      const dag = new DAGBuilder()
+        .agent('a', agent('a'))
+        .agent('b', agent('b'))
+        .edge('a', 'b', { handoff: 'standard' })
+        .build();
+
+      const graph = new DAGGraph(dag);
+      const executor = new DAGExecutor(
+        graph, mockRunner, new CostTracker(null, null),
+        new SwarmMemory(), 'test task',
+      );
+
+      const events: SwarmEvent[] = [];
+      for await (const event of executor.execute()) {
+        events.push(event);
+      }
+
+      // Node 'a' has an outgoing edge with handoff 'standard', so it should receive the resolved template
+      expect(capturedHandoff).toBeDefined();
+      expect(capturedHandoff).toHaveProperty('id', 'standard');
+      expect(capturedHandoff).toHaveProperty('sections');
+    });
+
+    it('does not pass handoff template when edge has none', async () => {
+      let capturedHandoff: unknown = 'NOT_SET';
+
+      const mockRunner = {
+        async *run(params: any): AsyncGenerator<SwarmEvent> {
+          if (params.nodeId === 'a') {
+            capturedHandoff = params.handoffTemplate;
+          }
+          yield { type: 'agent_start', nodeId: params.nodeId, agentRole: params.agent.role, agentName: params.agent.name };
+          yield { type: 'agent_done', nodeId: params.nodeId, agentRole: params.agent.role, output: `output-${params.nodeId}`, cost: emptyCost() };
+        },
+      } as AgentRunner;
+
+      const dag = new DAGBuilder()
+        .agent('a', agent('a'))
+        .agent('b', agent('b'))
+        .edge('a', 'b')
+        .build();
+
+      const graph = new DAGGraph(dag);
+      const executor = new DAGExecutor(
+        graph, mockRunner, new CostTracker(null, null),
+        new SwarmMemory(), 'test task',
+      );
+
+      for await (const event of executor.execute()) {}
+
+      expect(capturedHandoff).toBeUndefined();
+    });
+
+    it('passes handoff template to parallel runners', async () => {
+      const capturedHandoffs: Record<string, unknown> = {};
+
+      const mockRunner = {
+        async *run(params: any): AsyncGenerator<SwarmEvent> {
+          capturedHandoffs[params.nodeId] = params.handoffTemplate;
+          yield { type: 'agent_start', nodeId: params.nodeId, agentRole: params.agent.role, agentName: params.agent.name };
+          yield { type: 'agent_done', nodeId: params.nodeId, agentRole: params.agent.role, output: `output-${params.nodeId}`, cost: emptyCost() };
+        },
+      } as AgentRunner;
+
+      const dag = new DAGBuilder()
+        .agent('root', agent('root'))
+        .agent('left', agent('left'))
+        .agent('right', agent('right'))
+        .agent('merge', agent('merge'))
+        .edge('root', 'left')
+        .edge('root', 'right')
+        .edge('left', 'merge', { handoff: 'qa-review' })
+        .edge('right', 'merge', { handoff: 'standard' })
+        .build();
+
+      const graph = new DAGGraph(dag);
+      const executor = new DAGExecutor(
+        graph, mockRunner, new CostTracker(null, null),
+        new SwarmMemory(), 'test task',
+      );
+
+      for await (const event of executor.execute()) {}
+
+      // root has outgoing edges but no handoff
+      expect(capturedHandoffs['root']).toBeUndefined();
+      // left has an outgoing edge with handoff 'qa-review'
+      expect(capturedHandoffs['left']).toBeDefined();
+      expect(capturedHandoffs['left']).toHaveProperty('id', 'qa-review');
+      // right has an outgoing edge with handoff 'standard'
+      expect(capturedHandoffs['right']).toBeDefined();
+      expect(capturedHandoffs['right']).toHaveProperty('id', 'standard');
+    });
+  });
+
   describe('per-node provider routing', () => {
     it('resolves provider from providers map when node has providerId', async () => {
       const nodeA = { ...agent('a'), providerId: 'fast' };

--- a/tests/dag/feedback-edge.test.ts
+++ b/tests/dag/feedback-edge.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import { DAGBuilder } from '../../src/dag/builder.js';
+import { DAGGraph } from '../../src/dag/graph.js';
+import type { FeedbackEdge } from '../../src/types.js';
+
+function agent(id: string) {
+  return { id, name: id, role: id, systemPrompt: '' };
+}
+
+describe('DAGBuilder feedbackEdge', () => {
+  it('adds a feedback edge to the DAG definition', () => {
+    const dag = new DAGBuilder()
+      .agent('dev', agent('dev'))
+      .agent('qa', agent('qa'))
+      .edge('dev', 'qa')
+      .feedbackEdge({
+        from: 'qa',
+        to: 'dev',
+        maxRetries: 3,
+        evaluate: { type: 'regex', pattern: 'PASS', matchTarget: 'pass', elseTarget: 'fail' },
+        passLabel: 'pass',
+      })
+      .build();
+
+    expect(dag.feedbackEdges).toHaveLength(1);
+    expect(dag.feedbackEdges[0].from).toBe('qa');
+    expect(dag.feedbackEdges[0].to).toBe('dev');
+    expect(dag.feedbackEdges[0].maxRetries).toBe(3);
+    expect(dag.feedbackEdges[0].passLabel).toBe('pass');
+  });
+
+  it('supports escalation policy', () => {
+    const dag = new DAGBuilder()
+      .agent('dev', agent('dev'))
+      .agent('qa', agent('qa'))
+      .agent('senior', agent('senior'))
+      .edge('dev', 'qa')
+      .feedbackEdge({
+        from: 'qa',
+        to: 'dev',
+        maxRetries: 3,
+        evaluate: { type: 'regex', pattern: 'PASS', matchTarget: 'pass', elseTarget: 'fail' },
+        passLabel: 'pass',
+        escalation: { action: 'reroute', reroute: 'senior', message: 'Dev failed 3 times' },
+      })
+      .build();
+
+    expect(dag.feedbackEdges[0].escalation).toEqual({
+      action: 'reroute',
+      reroute: 'senior',
+      message: 'Dev failed 3 times',
+    });
+  });
+
+  it('validates feedback edge source node exists', () => {
+    expect(() => {
+      new DAGBuilder()
+        .agent('dev', agent('dev'))
+        .feedbackEdge({
+          from: 'nonexistent',
+          to: 'dev',
+          maxRetries: 3,
+          evaluate: { type: 'regex', pattern: 'PASS', matchTarget: 'pass', elseTarget: 'fail' },
+          passLabel: 'pass',
+        })
+        .build();
+    }).toThrow('non-existent source');
+  });
+
+  it('validates feedback edge target node exists', () => {
+    expect(() => {
+      new DAGBuilder()
+        .agent('qa', agent('qa'))
+        .feedbackEdge({
+          from: 'qa',
+          to: 'nonexistent',
+          maxRetries: 3,
+          evaluate: { type: 'regex', pattern: 'PASS', matchTarget: 'pass', elseTarget: 'fail' },
+          passLabel: 'pass',
+        })
+        .build();
+    }).toThrow('non-existent target');
+  });
+
+  it('validates escalation reroute node exists', () => {
+    expect(() => {
+      new DAGBuilder()
+        .agent('dev', agent('dev'))
+        .agent('qa', agent('qa'))
+        .feedbackEdge({
+          from: 'qa',
+          to: 'dev',
+          maxRetries: 3,
+          evaluate: { type: 'regex', pattern: 'PASS', matchTarget: 'pass', elseTarget: 'fail' },
+          passLabel: 'pass',
+          escalation: { action: 'reroute', reroute: 'nonexistent' },
+        })
+        .build();
+    }).toThrow('non-existent');
+  });
+
+  it('DAG without feedback edges has empty array', () => {
+    const dag = new DAGBuilder()
+      .agent('a', agent('a'))
+      .build();
+
+    expect(dag.feedbackEdges).toEqual([]);
+  });
+});
+
+describe('DAGGraph feedbackEdges', () => {
+  it('exposes feedback edges from definition', () => {
+    const dag = new DAGBuilder()
+      .agent('dev', agent('dev'))
+      .agent('qa', agent('qa'))
+      .edge('dev', 'qa')
+      .feedbackEdge({
+        from: 'qa',
+        to: 'dev',
+        maxRetries: 3,
+        evaluate: { type: 'regex', pattern: 'PASS', matchTarget: 'pass', elseTarget: 'fail' },
+        passLabel: 'pass',
+      })
+      .build();
+
+    const graph = new DAGGraph(dag);
+    expect(graph.feedbackEdges).toHaveLength(1);
+    expect(graph.feedbackEdges[0].from).toBe('qa');
+  });
+
+  it('getFeedbackEdges filters by source node', () => {
+    const dag = new DAGBuilder()
+      .agent('dev', agent('dev'))
+      .agent('qa', agent('qa'))
+      .agent('reviewer', agent('reviewer'))
+      .edge('dev', 'qa')
+      .edge('dev', 'reviewer')
+      .feedbackEdge({
+        from: 'qa',
+        to: 'dev',
+        maxRetries: 3,
+        evaluate: { type: 'regex', pattern: 'PASS', matchTarget: 'pass', elseTarget: 'fail' },
+        passLabel: 'pass',
+      })
+      .feedbackEdge({
+        from: 'reviewer',
+        to: 'dev',
+        maxRetries: 2,
+        evaluate: { type: 'regex', pattern: 'OK', matchTarget: 'pass', elseTarget: 'fail' },
+        passLabel: 'pass',
+      })
+      .build();
+
+    const graph = new DAGGraph(dag);
+
+    expect(graph.getFeedbackEdges('qa')).toHaveLength(1);
+    expect(graph.getFeedbackEdges('qa')[0].from).toBe('qa');
+
+    expect(graph.getFeedbackEdges('reviewer')).toHaveLength(1);
+    expect(graph.getFeedbackEdges('reviewer')[0].from).toBe('reviewer');
+
+    expect(graph.getFeedbackEdges('dev')).toHaveLength(0);
+  });
+
+  it('defaults to empty array when feedbackEdges not in definition', () => {
+    // Simulate a definition without feedbackEdges (backward compatibility)
+    const graph = new DAGGraph({
+      id: 'test',
+      nodes: [{ id: 'a', agent: agent('a') }],
+      edges: [],
+      conditionalEdges: [],
+      dynamicNodes: [],
+    } as any);
+
+    expect(graph.feedbackEdges).toEqual([]);
+  });
+});

--- a/tests/dag/feedback-loop.test.ts
+++ b/tests/dag/feedback-loop.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from 'vitest';
+import { DAGBuilder } from '../../src/dag/builder.js';
+import { DAGGraph } from '../../src/dag/graph.js';
+import { DAGExecutor } from '../../src/dag/executor.js';
+import { CostTracker } from '../../src/cost/tracker.js';
+import { SwarmMemory } from '../../src/memory/index.js';
+import type { SwarmEvent, CostSummary, FeedbackContext } from '../../src/types.js';
+
+function agent(id: string) {
+  return { id, name: id, role: id, systemPrompt: '' };
+}
+function emptyCost(): CostSummary {
+  return { inputTokens: 0, outputTokens: 0, totalTokens: 0, costCents: 0, calls: 0 };
+}
+
+describe('feedback loop execution', () => {
+  it('retries dev node with feedback when QA rejects', async () => {
+    let devRunCount = 0;
+    let capturedFeedbackContext: FeedbackContext | undefined;
+
+    const runner = {
+      async *run(params: any): AsyncGenerator<SwarmEvent> {
+        yield { type: 'agent_start', nodeId: params.nodeId, agentRole: params.agent.role, agentName: params.agent.name };
+
+        if (params.nodeId === 'dev') {
+          devRunCount++;
+          capturedFeedbackContext = params.feedbackContext;
+          yield { type: 'agent_done', nodeId: 'dev', agentRole: 'dev', output: `dev-output-v${devRunCount}`, cost: emptyCost() };
+        } else {
+          // QA: reject first time, pass second time
+          const output = devRunCount <= 1 ? 'FAIL: missing tests' : 'PASS: looks good';
+          yield { type: 'agent_done', nodeId: 'qa', agentRole: 'qa', output, cost: emptyCost() };
+        }
+      },
+    };
+
+    const dag = new DAGBuilder()
+      .agent('dev', agent('dev'))
+      .agent('qa', agent('qa'))
+      .edge('dev', 'qa')
+      .feedbackEdge({
+        from: 'qa',
+        to: 'dev',
+        maxRetries: 3,
+        evaluate: { type: 'regex', pattern: 'PASS', matchTarget: 'pass', elseTarget: 'fail' },
+        passLabel: 'pass',
+      })
+      .build();
+
+    const graph = new DAGGraph(dag);
+    const executor = new DAGExecutor(
+      graph, runner as any, new CostTracker(null, null),
+      new SwarmMemory(), 'test task',
+    );
+
+    const events: SwarmEvent[] = [];
+    for await (const event of executor.execute()) {
+      events.push(event);
+    }
+
+    // Dev ran twice: initial + 1 retry
+    expect(devRunCount).toBe(2);
+    // Feedback was injected on retry
+    expect(capturedFeedbackContext).toBeDefined();
+    expect(capturedFeedbackContext!.iteration).toBe(1);
+    expect(capturedFeedbackContext!.maxRetries).toBe(3);
+    expect(capturedFeedbackContext!.previousFeedback).toBe('FAIL: missing tests');
+    // Events include feedback_retry
+    expect(events.some(e => e.type === 'feedback_retry')).toBe(true);
+    // Swarm completed successfully
+    expect(events.find(e => e.type === 'swarm_done')).toBeDefined();
+  });
+
+  it('escalates with fail policy after maxRetries exhausted', async () => {
+    let devRunCount = 0;
+
+    const runner = {
+      async *run(params: any): AsyncGenerator<SwarmEvent> {
+        yield { type: 'agent_start', nodeId: params.nodeId, agentRole: params.agent.role, agentName: params.agent.name };
+
+        if (params.nodeId === 'dev') {
+          devRunCount++;
+          yield { type: 'agent_done', nodeId: 'dev', agentRole: 'dev', output: `bad-output-${devRunCount}`, cost: emptyCost() };
+        } else {
+          // QA always rejects
+          yield { type: 'agent_done', nodeId: 'qa', agentRole: 'qa', output: 'FAIL: still broken', cost: emptyCost() };
+        }
+      },
+    };
+
+    const dag = new DAGBuilder()
+      .agent('dev', agent('dev'))
+      .agent('qa', agent('qa'))
+      .edge('dev', 'qa')
+      .feedbackEdge({
+        from: 'qa',
+        to: 'dev',
+        maxRetries: 2,
+        evaluate: { type: 'regex', pattern: 'PASS', matchTarget: 'pass', elseTarget: 'fail' },
+        passLabel: 'pass',
+        escalation: { action: 'fail', message: 'Dev failed after 2 retries' },
+      })
+      .build();
+
+    const graph = new DAGGraph(dag);
+    const executor = new DAGExecutor(
+      graph, runner as any, new CostTracker(null, null),
+      new SwarmMemory(), 'test task',
+    );
+
+    const events: SwarmEvent[] = [];
+    for await (const event of executor.execute()) {
+      events.push(event);
+    }
+
+    // Dev ran exactly maxRetries times
+    expect(devRunCount).toBe(2);
+    // Escalation event emitted
+    const escalation = events.find(e => e.type === 'feedback_escalation');
+    expect(escalation).toBeDefined();
+    expect(escalation).toMatchObject({
+      fromNode: 'qa',
+      toNode: 'dev',
+      iteration: 2,
+    });
+  });
+
+  it('passes immediately when QA approves first time', async () => {
+    let devRunCount = 0;
+
+    const runner = {
+      async *run(params: any): AsyncGenerator<SwarmEvent> {
+        yield { type: 'agent_start', nodeId: params.nodeId, agentRole: params.agent.role, agentName: params.agent.name };
+
+        if (params.nodeId === 'dev') {
+          devRunCount++;
+          yield { type: 'agent_done', nodeId: 'dev', agentRole: 'dev', output: 'good code', cost: emptyCost() };
+        } else {
+          yield { type: 'agent_done', nodeId: 'qa', agentRole: 'qa', output: 'PASS: great work', cost: emptyCost() };
+        }
+      },
+    };
+
+    const dag = new DAGBuilder()
+      .agent('dev', agent('dev'))
+      .agent('qa', agent('qa'))
+      .edge('dev', 'qa')
+      .feedbackEdge({
+        from: 'qa',
+        to: 'dev',
+        maxRetries: 3,
+        evaluate: { type: 'regex', pattern: 'PASS', matchTarget: 'pass', elseTarget: 'fail' },
+        passLabel: 'pass',
+      })
+      .build();
+
+    const graph = new DAGGraph(dag);
+    const executor = new DAGExecutor(
+      graph, runner as any, new CostTracker(null, null),
+      new SwarmMemory(), 'test task',
+    );
+
+    const events: SwarmEvent[] = [];
+    for await (const event of executor.execute()) {
+      events.push(event);
+    }
+
+    // Dev only ran once
+    expect(devRunCount).toBe(1);
+    // No retry events
+    expect(events.some(e => e.type === 'feedback_retry')).toBe(false);
+    expect(events.some(e => e.type === 'feedback_escalation')).toBe(false);
+    // Swarm completed
+    expect(events.find(e => e.type === 'swarm_done')).toBeDefined();
+  });
+
+  it('accumulates feedback history across retries', async () => {
+    let devRunCount = 0;
+    const capturedFeedback: (FeedbackContext | undefined)[] = [];
+
+    const runner = {
+      async *run(params: any): AsyncGenerator<SwarmEvent> {
+        yield { type: 'agent_start', nodeId: params.nodeId, agentRole: params.agent.role, agentName: params.agent.name };
+
+        if (params.nodeId === 'dev') {
+          devRunCount++;
+          capturedFeedback.push(params.feedbackContext);
+          yield { type: 'agent_done', nodeId: 'dev', agentRole: 'dev', output: `attempt-${devRunCount}`, cost: emptyCost() };
+        } else {
+          // QA rejects first 2, passes on 3rd
+          const output = devRunCount <= 2 ? `FAIL: issue ${devRunCount}` : 'PASS: fixed';
+          yield { type: 'agent_done', nodeId: 'qa', agentRole: 'qa', output, cost: emptyCost() };
+        }
+      },
+    };
+
+    const dag = new DAGBuilder()
+      .agent('dev', agent('dev'))
+      .agent('qa', agent('qa'))
+      .edge('dev', 'qa')
+      .feedbackEdge({
+        from: 'qa',
+        to: 'dev',
+        maxRetries: 5,
+        evaluate: { type: 'regex', pattern: 'PASS', matchTarget: 'pass', elseTarget: 'fail' },
+        passLabel: 'pass',
+      })
+      .build();
+
+    const graph = new DAGGraph(dag);
+    const executor = new DAGExecutor(
+      graph, runner as any, new CostTracker(null, null),
+      new SwarmMemory(), 'test task',
+    );
+
+    for await (const _event of executor.execute()) {}
+
+    expect(devRunCount).toBe(3);
+    // First run: no feedback
+    expect(capturedFeedback[0]).toBeUndefined();
+    // Second run: one piece of feedback
+    expect(capturedFeedback[1]?.iteration).toBe(1);
+    expect(capturedFeedback[1]?.feedbackHistory).toHaveLength(1);
+    // Third run: two pieces of feedback
+    expect(capturedFeedback[2]?.iteration).toBe(2);
+    expect(capturedFeedback[2]?.feedbackHistory).toHaveLength(2);
+  });
+});

--- a/tests/dag/validator.test.ts
+++ b/tests/dag/validator.test.ts
@@ -392,6 +392,113 @@ describe('validateDAG', () => {
     expect(result.errors.some(e => e.includes('ghost'))).toBe(true);
   });
 
+  // --- Feedback edge validation ---
+
+  describe('feedback edge validation', () => {
+    it('passes for valid feedback edges', () => {
+      const dag: DAGDefinition = {
+        id: 'test',
+        nodes: [
+          { id: 'dev', agent: agent('dev') },
+          { id: 'qa', agent: agent('qa') },
+        ],
+        edges: [{ from: 'dev', to: 'qa' }],
+        conditionalEdges: [],
+        feedbackEdges: [{
+          from: 'qa', to: 'dev', maxRetries: 3,
+          evaluate: { type: 'regex', pattern: 'PASS', matchTarget: 'pass', elseTarget: 'fail' },
+          passLabel: 'pass',
+        }],
+        dynamicNodes: [],
+      };
+      const result = validateDAG(dag);
+      expect(result.valid).toBe(true);
+    });
+
+    it('fails for feedback edge with non-existent source', () => {
+      const dag: DAGDefinition = {
+        id: 'test',
+        nodes: [
+          { id: 'dev', agent: agent('dev') },
+        ],
+        edges: [],
+        conditionalEdges: [],
+        feedbackEdges: [{
+          from: 'nonexistent', to: 'dev', maxRetries: 3,
+          evaluate: { type: 'regex', pattern: 'PASS', matchTarget: 'pass', elseTarget: 'fail' },
+          passLabel: 'pass',
+        }],
+        dynamicNodes: [],
+      };
+      const result = validateDAG(dag);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('nonexistent');
+    });
+
+    it('fails for feedback edge with non-existent target', () => {
+      const dag: DAGDefinition = {
+        id: 'test',
+        nodes: [
+          { id: 'qa', agent: agent('qa') },
+        ],
+        edges: [],
+        conditionalEdges: [],
+        feedbackEdges: [{
+          from: 'qa', to: 'nonexistent', maxRetries: 3,
+          evaluate: { type: 'regex', pattern: 'PASS', matchTarget: 'pass', elseTarget: 'fail' },
+          passLabel: 'pass',
+        }],
+        dynamicNodes: [],
+      };
+      const result = validateDAG(dag);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('nonexistent');
+    });
+
+    it('fails for feedback edge with non-existent escalation reroute', () => {
+      const dag: DAGDefinition = {
+        id: 'test',
+        nodes: [
+          { id: 'dev', agent: agent('dev') },
+          { id: 'qa', agent: agent('qa') },
+        ],
+        edges: [{ from: 'dev', to: 'qa' }],
+        conditionalEdges: [],
+        feedbackEdges: [{
+          from: 'qa', to: 'dev', maxRetries: 3,
+          evaluate: { type: 'regex', pattern: 'PASS', matchTarget: 'pass', elseTarget: 'fail' },
+          passLabel: 'pass',
+          escalation: { action: 'reroute', reroute: 'nonexistent' },
+        }],
+        dynamicNodes: [],
+      };
+      const result = validateDAG(dag);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('nonexistent');
+    });
+
+    it('detects provider reference in feedback edge evaluator', () => {
+      const dag: DAGDefinition = {
+        id: 'test',
+        nodes: [
+          { id: 'dev', agent: agent('dev') },
+          { id: 'qa', agent: agent('qa') },
+        ],
+        edges: [{ from: 'dev', to: 'qa' }],
+        conditionalEdges: [],
+        feedbackEdges: [{
+          from: 'qa', to: 'dev', maxRetries: 3,
+          evaluate: { type: 'llm', prompt: 'evaluate', providerId: 'missing-provider' },
+          passLabel: 'pass',
+        }],
+        dynamicNodes: [],
+      };
+      const result = validateDAG(dag, { providers: { anthropic: {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('missing-provider'))).toBe(true);
+    });
+  });
+
   // --- Edge cases ---
 
   it('handles empty DAG', () => {

--- a/tests/dag/validator.test.ts
+++ b/tests/dag/validator.test.ts
@@ -23,6 +23,7 @@ function simpleDag(overrides?: Partial<DAGDefinition>): DAGDefinition {
     ],
     edges: [{ from: 'a', to: 'b' }],
     conditionalEdges: [],
+    feedbackEdges: [],
     dynamicNodes: [],
     ...overrides,
   };
@@ -359,6 +360,7 @@ describe('validateDAG', () => {
           targets: { pass: 'b' },
         },
       ],
+      feedbackEdges: [],
       dynamicNodes: [],
     };
 
@@ -381,6 +383,7 @@ describe('validateDAG', () => {
           targets: { pass: 'ghost' },
         },
       ],
+      feedbackEdges: [],
       dynamicNodes: [],
     };
 

--- a/tests/guards/evidence.test.ts
+++ b/tests/guards/evidence.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { evidenceGuard } from '../../src/guards/evidence.js';
+
+describe('evidence guard', () => {
+  it('warns when claims present but no evidence', () => {
+    const result = evidenceGuard('All tests pass and everything works correctly.');
+    expect(result.triggered).toBe(true);
+    expect(result.claims).toContain('all tests pass');
+  });
+
+  it('passes when claims have code block evidence', () => {
+    const result = evidenceGuard(
+      'All tests pass.\n\n```\n$ npm test\n✓ 42 tests passed\n```',
+    );
+    expect(result.triggered).toBe(false);
+  });
+
+  it('passes when no claims made', () => {
+    const result = evidenceGuard('Here is the implementation for the auth module.');
+    expect(result.triggered).toBe(false);
+  });
+
+  it('detects multiple claim patterns', () => {
+    const result = evidenceGuard('No issues found. Verified successfully.');
+    expect(result.triggered).toBe(true);
+    expect(result.claims.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('recognizes file paths as evidence', () => {
+    const result = evidenceGuard(
+      'All tests pass. See results in src/tests/output.log and /tmp/results.json',
+    );
+    expect(result.triggered).toBe(false);
+  });
+
+  it('recognizes command outputs as evidence', () => {
+    const result = evidenceGuard(
+      'Verified successfully.\n\n$ vitest run\nTests: 5 passed',
+    );
+    expect(result.triggered).toBe(false);
+  });
+});

--- a/tests/guards/runner.test.ts
+++ b/tests/guards/runner.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { runGuards } from '../../src/guards/runner.js';
+import type { Guard, ProviderAdapter, ProviderEvent } from '../../src/types.js';
+
+function createMockProvider(response: string): ProviderAdapter {
+  return {
+    async *stream(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'chunk', content: response };
+      yield { type: 'usage', inputTokens: 10, outputTokens: 5 };
+    },
+    estimateCost: () => 0,
+    getModelLimits: () => ({ contextWindow: 100000, maxOutput: 4096 }),
+  };
+}
+
+describe('runGuards', () => {
+  it('returns empty results when no guards', async () => {
+    const results = await runGuards([], 'task', 'output');
+    expect(results).toEqual([]);
+  });
+
+  it('runs evidence guard and returns warning', async () => {
+    const guards: Guard[] = [{ id: 'ev', type: 'evidence', mode: 'warn' }];
+    const results = await runGuards(guards, 'task', 'All tests pass.');
+    expect(results).toHaveLength(1);
+    expect(results[0].guardId).toBe('ev');
+    expect(results[0].triggered).toBe(true);
+    expect(results[0].blocked).toBe(false);
+  });
+
+  it('evidence guard in block mode sets blocked', async () => {
+    const guards: Guard[] = [{ id: 'ev', type: 'evidence', mode: 'block' }];
+    const results = await runGuards(guards, 'task', 'All tests pass.');
+    expect(results[0].blocked).toBe(true);
+  });
+
+  it('runs scope-creep guard with provider', async () => {
+    const provider = createMockProvider('OVERSCOPED: added extra features');
+    const guards: Guard[] = [{ id: 'sc', type: 'scope-creep', mode: 'warn' }];
+    const results = await runGuards(guards, 'Build X', 'Built X plus Y and Z', provider);
+    expect(results).toHaveLength(1);
+    expect(results[0].triggered).toBe(true);
+  });
+
+  it('skips scope-creep guard when no provider', async () => {
+    const guards: Guard[] = [{ id: 'sc', type: 'scope-creep', mode: 'warn' }];
+    const results = await runGuards(guards, 'task', 'output');
+    expect(results).toHaveLength(1);
+    expect(results[0].triggered).toBe(false);
+    expect(results[0].skipped).toBe(true);
+  });
+
+  it('sorts guards: evidence first, then scope-creep', async () => {
+    const provider = createMockProvider('SCOPED');
+    const guards: Guard[] = [
+      { id: 'sc', type: 'scope-creep', mode: 'warn' },
+      { id: 'ev', type: 'evidence', mode: 'warn' },
+    ];
+    const results = await runGuards(guards, 'task', 'All tests pass.', provider);
+    expect(results[0].guardId).toBe('ev');
+    expect(results[1].guardId).toBe('sc');
+  });
+});

--- a/tests/guards/scope-creep.test.ts
+++ b/tests/guards/scope-creep.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { scopeCreepGuard } from '../../src/guards/scope-creep.js';
+import type { ProviderAdapter, ProviderEvent } from '../../src/types.js';
+
+function createMockProvider(response: string): ProviderAdapter {
+  return {
+    async *stream(): AsyncGenerator<ProviderEvent> {
+      yield { type: 'chunk', content: response };
+      yield { type: 'usage', inputTokens: 10, outputTokens: 5 };
+    },
+    estimateCost: () => 0,
+    getModelLimits: () => ({ contextWindow: 100000, maxOutput: 4096 }),
+  };
+}
+
+describe('scope creep guard', () => {
+  it('returns not triggered when output is scoped', async () => {
+    const provider = createMockProvider('SCOPED');
+    const result = await scopeCreepGuard(
+      'Build a login form',
+      'Here is the login form with email and password fields.',
+      provider,
+    );
+    expect(result.triggered).toBe(false);
+    expect(result.message).toBe('');
+  });
+
+  it('returns triggered when output is overscoped', async () => {
+    const provider = createMockProvider('OVERSCOPED: Added user registration and password reset beyond the request');
+    const result = await scopeCreepGuard(
+      'Build a login form',
+      'Here is the login form, plus I also added user registration, password reset, and SSO integration.',
+      provider,
+    );
+    expect(result.triggered).toBe(true);
+    expect(result.message).toContain('OVERSCOPED');
+  });
+
+  it('requires a provider', async () => {
+    await expect(
+      scopeCreepGuard('task', 'output', undefined as any),
+    ).rejects.toThrow('provider');
+  });
+
+  it('truncates long output to 3000 chars', async () => {
+    let capturedContent = '';
+    const provider: ProviderAdapter = {
+      async *stream(params: any): AsyncGenerator<ProviderEvent> {
+        capturedContent = params.messages[1].content;
+        yield { type: 'chunk', content: 'SCOPED' };
+        yield { type: 'usage', inputTokens: 10, outputTokens: 5 };
+      },
+      estimateCost: () => 0,
+      getModelLimits: () => ({ contextWindow: 100000, maxOutput: 4096 }),
+    };
+
+    const longOutput = 'x'.repeat(5000);
+    await scopeCreepGuard('task', longOutput, provider);
+
+    // The output in the prompt should be truncated
+    expect(capturedContent.length).toBeLessThan(5000 + 100); // 3000 + "Task: task\n\nOutput:\n" prefix
+  });
+});

--- a/tests/handoffs/formatter.test.ts
+++ b/tests/handoffs/formatter.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { formatHandoffInstructions, formatHandoffOutput } from '../../src/handoffs/formatter.js';
+import type { HandoffTemplate } from '../../src/types.js';
+
+const template: HandoffTemplate = {
+  id: 'test',
+  sections: [
+    { key: 'summary', label: 'Summary', required: true },
+    { key: 'details', label: 'Details' },
+  ],
+};
+
+describe('formatHandoffInstructions', () => {
+  it('generates output formatting instructions from template', () => {
+    const result = formatHandoffInstructions(template);
+    expect(result).toContain('## Summary (REQUIRED)');
+    expect(result).toContain('## Details');
+    expect(result).not.toContain('Details (REQUIRED)');
+    expect(result).toContain('## Output Format');
+  });
+});
+
+describe('formatHandoffOutput', () => {
+  it('wraps raw output with structured header', () => {
+    const raw = '## Summary\nDid the thing\n\n## Details\nMore info';
+    const result = formatHandoffOutput(template, raw, 'dev', 'node-1');
+    expect(result).toContain('Output from dev (node-1)');
+    expect(result).toContain('Did the thing');
+    expect(result).toContain('More info');
+  });
+
+  it('passes through raw output unchanged when no template sections detected', () => {
+    const raw = 'Just plain text output';
+    const result = formatHandoffOutput(template, raw, 'dev', 'node-1');
+    expect(result).toContain('Just plain text output');
+    expect(result).toContain('Output from dev (node-1)');
+  });
+});

--- a/tests/handoffs/templates.test.ts
+++ b/tests/handoffs/templates.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { HANDOFF_PRESETS, getHandoffTemplate } from '../../src/handoffs/templates.js';
+import type { HandoffTemplate } from '../../src/types.js';
+
+describe('HANDOFF_PRESETS', () => {
+  const expectedPresets = ['standard', 'qa-review', 'qa-feedback', 'escalation'];
+
+  it('contains all four built-in presets', () => {
+    for (const name of expectedPresets) {
+      expect(HANDOFF_PRESETS).toHaveProperty(name);
+    }
+    expect(Object.keys(HANDOFF_PRESETS)).toHaveLength(4);
+  });
+
+  it('each preset has id matching its key', () => {
+    for (const [key, template] of Object.entries(HANDOFF_PRESETS)) {
+      expect(template.id).toBe(key);
+    }
+  });
+
+  it('each preset has non-empty sections', () => {
+    for (const template of Object.values(HANDOFF_PRESETS)) {
+      expect(template.sections.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('standard preset has correct sections', () => {
+    const t = HANDOFF_PRESETS.standard;
+    const keys = t.sections.map((s) => s.key);
+    expect(keys).toContain('summary');
+    expect(keys).toContain('deliverables');
+    expect(keys).toContain('context_for_next');
+    // summary and deliverables are required
+    expect(t.sections.find((s) => s.key === 'summary')?.required).toBe(true);
+    expect(t.sections.find((s) => s.key === 'deliverables')?.required).toBe(true);
+    expect(t.sections.find((s) => s.key === 'context_for_next')?.required).toBeFalsy();
+  });
+
+  it('qa-review preset has correct sections', () => {
+    const t = HANDOFF_PRESETS['qa-review'];
+    const keys = t.sections.map((s) => s.key);
+    expect(keys).toContain('deliverables');
+    expect(keys).toContain('test_criteria');
+    expect(keys).toContain('known_limitations');
+    expect(t.sections.find((s) => s.key === 'deliverables')?.required).toBe(true);
+    expect(t.sections.find((s) => s.key === 'test_criteria')?.required).toBe(true);
+    expect(t.sections.find((s) => s.key === 'known_limitations')?.required).toBeFalsy();
+  });
+
+  it('qa-feedback preset has correct sections', () => {
+    const t = HANDOFF_PRESETS['qa-feedback'];
+    const keys = t.sections.map((s) => s.key);
+    expect(keys).toContain('verdict');
+    expect(keys).toContain('issues_found');
+    expect(keys).toContain('suggestions');
+    expect(t.sections.find((s) => s.key === 'verdict')?.required).toBe(true);
+    expect(t.sections.find((s) => s.key === 'issues_found')?.required).toBe(true);
+    expect(t.sections.find((s) => s.key === 'suggestions')?.required).toBeFalsy();
+  });
+
+  it('escalation preset has correct sections', () => {
+    const t = HANDOFF_PRESETS.escalation;
+    const keys = t.sections.map((s) => s.key);
+    expect(keys).toContain('problem_description');
+    expect(keys).toContain('attempts_made');
+    expect(keys).toContain('recommendation');
+    expect(t.sections.find((s) => s.key === 'problem_description')?.required).toBe(true);
+    expect(t.sections.find((s) => s.key === 'attempts_made')?.required).toBe(true);
+    expect(t.sections.find((s) => s.key === 'recommendation')?.required).toBe(true);
+  });
+});
+
+describe('getHandoffTemplate', () => {
+  it('resolves a preset by name', () => {
+    const t = getHandoffTemplate('standard');
+    expect(t.id).toBe('standard');
+    expect(t.sections.length).toBeGreaterThan(0);
+  });
+
+  it('resolves all preset names', () => {
+    for (const name of ['standard', 'qa-review', 'qa-feedback', 'escalation']) {
+      const t = getHandoffTemplate(name);
+      expect(t.id).toBe(name);
+    }
+  });
+
+  it('returns inline template as-is when given a HandoffTemplate object', () => {
+    const inline: HandoffTemplate = {
+      id: 'custom',
+      sections: [{ key: 'notes', label: 'Notes', required: true }],
+    };
+    const t = getHandoffTemplate(inline);
+    expect(t).toBe(inline);
+  });
+
+  it('throws for unknown preset name', () => {
+    expect(() => getHandoffTemplate('nonexistent')).toThrow();
+  });
+});

--- a/tests/integration/feedback-guards.test.ts
+++ b/tests/integration/feedback-guards.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { SwarmEngine } from '../../src/engine.js';
+import type { SwarmEvent, ProviderAdapter, ProviderEvent, StreamParams } from '../../src/types.js';
+
+/**
+ * Integration test: Dev -> QA loop with handoff templates and evidence guard.
+ */
+
+function createTestProvider(): ProviderAdapter {
+  let callCount = 0;
+  return {
+    async *stream(params: StreamParams): AsyncGenerator<ProviderEvent> {
+      callCount++;
+      // Simple mock: return task-derived output
+      const userMsg = params.messages[params.messages.length - 1].content;
+      yield { type: 'chunk', content: userMsg.slice(0, 200) };
+      yield { type: 'usage', inputTokens: 50, outputTokens: 20 };
+    },
+    estimateCost: () => 0.01,
+    getModelLimits: () => ({ contextWindow: 100000, maxOutput: 4096 }),
+  };
+}
+
+describe('integration: feedback loop with handoffs', () => {
+  it('runs a dev-qa feedback loop via SwarmEngine', async () => {
+    const engine = new SwarmEngine({
+      providers: {
+        test: { type: 'custom', adapter: createTestProvider() },
+      },
+      defaults: { provider: 'test', model: 'test-model' },
+    });
+
+    const dag = engine.dag()
+      .agent('dev', {
+        id: 'dev', name: 'Developer', role: 'developer',
+        systemPrompt: 'You are a developer.',
+      })
+      .agent('qa', {
+        id: 'qa', name: 'QA', role: 'qa',
+        systemPrompt: 'You are a QA reviewer.',
+      })
+      .edge('dev', 'qa', { handoff: 'qa-review' })
+      .feedbackEdge({
+        from: 'qa',
+        to: 'dev',
+        maxRetries: 3,
+        evaluate: { type: 'rule', fn: (output) => output.includes('PASS') ? 'pass' : 'fail' },
+        passLabel: 'pass',
+        escalation: { action: 'fail', message: 'QA rejected after 3 attempts' },
+      })
+      .build();
+
+    const events: SwarmEvent[] = [];
+    for await (const event of engine.run({ dag, task: 'Build auth module' })) {
+      events.push(event);
+    }
+
+    // Should have started
+    expect(events.find(e => e.type === 'swarm_start')).toBeDefined();
+    // The mock provider won't produce 'PASS' so escalation will happen
+    expect(events.some(e => e.type === 'feedback_escalation')).toBe(true);
+  });
+
+  it('passes through when QA approves via rule evaluator', async () => {
+    const engine = new SwarmEngine({
+      providers: {
+        test: { type: 'custom', adapter: createTestProvider() },
+      },
+      defaults: { provider: 'test', model: 'test-model' },
+    });
+
+    const dag = engine.dag()
+      .agent('dev', {
+        id: 'dev', name: 'Developer', role: 'developer',
+        systemPrompt: 'You are a developer.',
+      })
+      .agent('qa', {
+        id: 'qa', name: 'QA', role: 'qa',
+        systemPrompt: 'You are a QA reviewer.',
+      })
+      .edge('dev', 'qa')
+      .feedbackEdge({
+        from: 'qa',
+        to: 'dev',
+        maxRetries: 3,
+        // This rule always passes
+        evaluate: { type: 'rule', fn: () => 'pass' },
+        passLabel: 'pass',
+      })
+      .build();
+
+    const events: SwarmEvent[] = [];
+    for await (const event of engine.run({ dag, task: 'Build auth module' })) {
+      events.push(event);
+    }
+
+    // No retries
+    expect(events.some(e => e.type === 'feedback_retry')).toBe(false);
+    // Completed successfully
+    expect(events.find(e => e.type === 'swarm_done')).toBeDefined();
+  });
+
+  it('engine-wide guards emit warnings', async () => {
+    const engine = new SwarmEngine({
+      providers: {
+        test: { type: 'custom', adapter: createTestProvider() },
+      },
+      defaults: { provider: 'test', model: 'test-model' },
+      guards: [{ id: 'ev', type: 'evidence', mode: 'warn' as const }],
+    });
+
+    const dag = engine.dag()
+      .agent('dev', {
+        id: 'dev', name: 'Developer', role: 'developer',
+        systemPrompt: 'You are a developer.',
+      })
+      .build();
+
+    const events: SwarmEvent[] = [];
+    for await (const event of engine.run({ dag, task: 'Build auth module' })) {
+      events.push(event);
+    }
+
+    // The mock output likely triggers evidence guard since it echoes the task without evidence
+    // Whether it triggers depends on the output - just verify the swarm completes
+    expect(events.find(e => e.type === 'swarm_done')).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- **Handoff Templates**: Structured output formatting between DAG nodes via edge configuration. 4 built-in presets (`standard`, `qa-review`, `qa-feedback`, `escalation`) plus inline custom templates. Templates inject output format instructions into producing agent's system prompt.
- **Feedback Loops**: Engine-managed retry with feedback injection. QA node output is evaluated, and if rejected, the dev node is reset with `FeedbackContext` (iteration count, previous feedback, full history). Configurable escalation policy (`skip`/`fail`/`reroute`) after max retries.
- **Anti-Pattern Guards**: Post-completion output quality checks. Evidence guard (pattern-matching, no LLM) detects unsupported claims. Scope creep guard (LLM-based, cheap) detects work beyond task scope. Configurable `warn`/`block` modes per guard, per node or engine-wide.

All features are additive and fully backwards compatible — no existing behavior changes without opt-in.

**430 tests passing across 48 test files. Build clean.**

## Changes

| Area | Files | What |
|------|-------|------|
| Types | `src/types.ts` | `HandoffTemplate`, `FeedbackEdge`, `EscalationPolicy`, `FeedbackContext`, `Guard`, new event types |
| Handoffs | `src/handoffs/` | Template presets, resolver, formatter |
| Guards | `src/guards/` | Evidence guard, scope creep guard, runner |
| DAG | `src/dag/executor.ts`, `builder.ts`, `graph.ts`, `validator.ts` | Feedback loop execution, guard post-completion, handoff wiring |
| Context | `src/context/assembler.ts` | Handoff instructions + feedback context injection |
| Agent | `src/agent/runner.ts`, `agentic-runner.ts` | Pass-through handoff/feedback params |
| Docs | `README.md`, `CHANGELOG.md` | Feature documentation, usage examples |

## Test plan

- [x] 11 handoff template tests (presets, resolver, edge cases)
- [x] 3 formatter tests (instructions generation, output formatting)
- [x] 9 feedback edge tests (evaluation, retry, escalation)
- [x] 4 feedback loop integration tests (multi-cycle retry with context injection)
- [x] 6 evidence guard tests (claims + evidence patterns)
- [x] 4 scope creep guard tests (LLM evaluation)
- [x] 6 guard runner tests (ordering, mode behavior, graceful degradation)
- [x] 5 executor guard integration tests (warn/block modes in DAG execution)
- [x] 3 end-to-end integration tests (feedback loop + guards combined)
- [x] 5 validator tests (feedback edge validation rules)
- [x] 5 assembler tests (handoff + feedback context assembly)
- [x] 3 builder tests (feedbackEdge, handoff on edges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)